### PR TITLE
Persist keyversion in KMS provider config, limit leaseblob to 60s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ variables:
     name: Create credentials file
     command: |
       sudo mkdir /etc/kubernetes
-      echo -e '{\n    "tenantId": "'$TENANT_ID'",\n    "subscriptionId": "'$SUBSCRIPTION_ID'",\n    "aadClientId": "'$CLIENT_ID'",\n    "aadClientSecret": "'$CLIENT_SECRET'",\n    "resourceGroup": "'$RESOURCE_GROUP'",\n    "location": "'$LOCATION'",\n    "providerVaultName": "'$KV_NAME'",\n    "providerKeyName": "'$KV_KEY'"\n}' | sudo tee --append /etc/kubernetes/azure.json  > /dev/null
+      echo -e '{\n    "tenantId": "'$TENANT_ID'",\n    "subscriptionId": "'$SUBSCRIPTION_ID'",\n    "aadClientId": "'$CLIENT_ID'",\n    "aadClientSecret": "'$CLIENT_SECRET'",\n    "resourceGroup": "'$RESOURCE_GROUP'",\n    "location": "'$LOCATION'",\n    "providerVaultName": "'$KV_NAME'",\n    "providerKeyName": "'$KV_KEY'",\n    "providerKeyVersion": ""\n}' | sudo tee --append /etc/kubernetes/azure.json  > /dev/null
   - &build
     name: Build
     command:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 binary := kubernetes-kms
 DOCKER_IMAGE := microsoft/k8s-azure-kms
 
-VERSION          := v0.0.2
+VERSION          := v0.0.3
 CGO_ENABLED_FLAG := 0
 
 ifeq ($(OS),Windows_NT)

--- a/developers.md
+++ b/developers.md
@@ -48,7 +48,7 @@ We use `make` and `Makefile` to build the binary and the Docker image. To start 
 
 To test your code locally:
 
-1. On a linux machine, you can run `sudo ./kubernetes-kms` to create the gRPC unix domain socket running at `/opt/azurekms.socket`. This will start the gRPC server.
+1. On a linux machine, you can run `sudo ./kubernetes-kms --configFilePath <PATH TO YOUR AZURE.JSON FILE>` to create the gRPC unix domain socket running at `/opt/azurekms.socket`. This will start the gRPC server.
 2. Create an Azure resource group, a Key Vault, and update the key vault's access policy with:
 
 ```bash
@@ -58,7 +58,7 @@ az keyvault set-policy -n k8skv --key-permissions create decrypt encrypt get lis
 ```
 If you do not have a service principal, please refer to this [doc](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest).
 
-3. Populate a `azure.json` file locally and store it under `/etc/kubernetes/` that's where the gRPC server will look for this file:
+3. Populate a `azure.json` file locally. The gRPC server will look for this file in the path provided by `configFilePath`. By default, `configFilePath` is set to `etc/kubernetes/azure.json`. 
 
 ```json
 {

--- a/developers.md
+++ b/developers.md
@@ -72,7 +72,7 @@ If you do not have a service principal, please refer to this [doc](https://docs.
     "providerKeyName": "mykey"
 }
 ```
-4. Test with the gRPC client, run `sudo GOPATH=[YOUR GOPATH] go test test/client/client_test.go`.
+4. Test with the gRPC client, run `sudo GOPATH=[YOUR GOPATH] go test tests/client/client_test.go`.
 5. Test racing condition with the gRPC client, run `sudo GOPATH=[YOUR GOPATH] go test test/client/client_test.go & sudo GOPATH=[YOUR GOPATH] go test test/client/client_test.go &`.
 
 ### Build image


### PR DESCRIPTION
- Store `providerKeyVersion` in azure.json
   - Store keyversion after a new key is created
   - Get latest keyversion if key already exists and if`providerKeyVersion` is `""` in azure.json
- limit leastblob to `60` seconds instead of unlimited `-1`
- make `configFilePath` configurable
- Update developer doc
- Update KMS provider version to `v0.0.3`
