### PR TITLE
Fix issue caused by updating azure.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 binary := kubernetes-kms
 DOCKER_IMAGE := microsoft/k8s-azure-kms
 
-VERSION          := v0.0.4
+VERSION          := v0.0.5
 CGO_ENABLED_FLAG := 0
 
 ifeq ($(OS),Windows_NT)

--- a/oauth.go
+++ b/oauth.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"strings"
 	"golang.org/x/crypto/pkcs12"
@@ -113,6 +114,10 @@ func GetAzureAuthConfig(configFilePath string) (azConfig *AzureAuthConfig, err e
 	if err != nil {
 		return nil, err
 	}
+	if config == nil {
+		log.Println("GetAzureAuthConfig config is nil while getting updated")
+		return nil, fmt.Errorf("GetAzureAuthConfig config is nil while getting updated")
+	}
 	if ( &config.AzureAuthConfig != nil ) {
 		return &config.AzureAuthConfig, nil
 	}
@@ -125,7 +130,10 @@ func GetKMSProvider(configFilePath string) (vaultName *string, keyName *string, 
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	
+	if config == nil {
+		log.Println("GetKMSProvider config is nil while getting updated")
+		return nil, nil, nil, nil, fmt.Errorf("GetKMSProvider config is nil while getting updated")
+	}
 	if (config.ProviderVaultName != "" ) {
 		vaultName = &config.ProviderVaultName
 	} else {
@@ -177,7 +185,6 @@ func UpdateKMSProvider(configFilePath string, keyVersion string) (err error) {
 			return fmt.Errorf("providerKeyVersion is missing from config file")
 		}
 		newConfig := strings.Join(lines, "\n")
-
 		err = ioutil.WriteFile(configFilePath, []byte(newConfig), 0644)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes https://github.com/Azure/aks-engine/issues/49

- When an encrypt request or a decrypt request occurs during a config (azure.json) update, config can be nil as the content is inflight. Handle nil config during a config update.
- Update the local `providerKeyVersion` property once we get a keyversion from keyvault so that we only update the config when `providerKeyVersion` is empty