### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->
+
+**Reason for Change**:
+<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
+
+
+**Issue Fixed**:
+<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
+
+**Notes for Reviewers**:


### PR DESCRIPTION
Provides a bit of organizational guidance for new pull requests, and checks another [community standards](https://github.com/Azure/kubernetes-kms/community) box.

See also Azure/aad-pod-identity#235 and Azure/kubernetes-keyvault-flexvol#98.