### PR TITLE
feat: switch to debian base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ azure.json
 .DS_Store
 
 .idea/
+
+_output/

--- a/.pipelines/pr.yml
+++ b/.pipelines/pr.yml
@@ -1,4 +1,7 @@
-trigger: none
+trigger:
+  branches:
+    include:
+    - master
 
 pr:
   branches:

--- a/.pipelines/scan-images.yml
+++ b/.pipelines/scan-images.yml
@@ -1,0 +1,13 @@
+steps:
+  - script: |
+      export REGISTRY="e2e"
+      export IMAGE_VERSION="test"
+      make build-image
+      wget https://github.com/aquasecurity/trivy/releases/download/v$(TRIVY_VERSION)/trivy_$(TRIVY_VERSION)_Linux-64bit.tar.gz
+      tar zxvf trivy_$(TRIVY_VERSION)_Linux-64bit.tar.gz
+
+      # show all vulnerabilities in the logs
+      ./trivy "${REGISTRY}/keyvault:${IMAGE_VERSION}"
+      
+      ./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/keyvault:${IMAGE_VERSION}" || exit 1
+    displayName: "Scan images for vulnerability"

--- a/.pipelines/unit-tests-template.yml
+++ b/.pipelines/unit-tests-template.yml
@@ -1,6 +1,6 @@
 jobs:
   - job: unit_tests
-    timeoutInMinutes: 20
+    timeoutInMinutes: 10
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all
@@ -23,8 +23,9 @@ jobs:
           CLIENT_ID: $(AZURE_CLIENT_ID)
           CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
       - script: |
-          sudo ./kubernetes-kms > /dev/null &
+          sudo ./_output/kubernetes-kms > /dev/null &
           echo Waiting 2 seconds for the server to start
           sleep 2
           make integration-test
-        displayName: Run intergration tests
+        displayName: Run integration tests
+      - template: scan-images.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM alpine:3.12
-WORKDIR /bin
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.2.0
+COPY ./_output/kubernetes-kms /bin/
+# upgrading apt &libapt-pkg5.0 due to CVE-2020-27350
+# upgrading libp11-kit0 due to CVE-2020-29362, CVE-2020-29363 and CVE-2020-29361
+RUN apt-mark unhold apt && \
+    clean-install ca-certificates apt libapt-pkg5.0 libp11-kit0 wget
 
-ADD ./kubernetes-kms /bin/k8s-azure-kms
-
-CMD ["./k8s-azure-kms"]
+ENTRYPOINT [ "/bin/kubernetes-kms" ]


### PR DESCRIPTION
<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
- Switches to using debian base image. 
  - `distroless` image is currently not used because of dep on azure.json
- Enables image vuln scanning as part of CI
- Refactors Makefile

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #58 
fixes #68

**Notes for Reviewers**:
