### PR TITLE
chore: update debian-base image to buster-v1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.2.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.3.0
 COPY ./_output/kubernetes-kms /bin/
-# upgrading apt &libapt-pkg5.0 due to CVE-2020-27350
-# upgrading libp11-kit0 due to CVE-2020-29362, CVE-2020-29363 and CVE-2020-29361
-RUN apt-mark unhold apt && \
-    clean-install ca-certificates apt libapt-pkg5.0 libp11-kit0 wget
 
 ENTRYPOINT [ "/bin/kubernetes-kms" ]


### PR DESCRIPTION
<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
