### PR TITLE
feat: add healthz check for kms plugin

### DIFF
--- a/pkg/plugin/healthz.go
+++ b/pkg/plugin/healthz.go
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"google.golang.org/grpc"
+	pb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
+	"k8s.io/klog/v2"
+
+	"github.com/Azure/kubernetes-kms/pkg/version"
+)
+
+const (
+	healthCheckPlainText = "healthcheck"
+)
+
+type HealthZ struct {
+	KMSServer      *KeyManagementServiceServer
+	HealthCheckURL *url.URL
+	UnixSocketPath string
+	RPCTimeout     time.Duration
+}
+
+// Serve creates the http handler for serving health requests
+func (h *HealthZ) Serve() {
+	serveMux := http.NewServeMux()
+	serveMux.HandleFunc(h.HealthCheckURL.EscapedPath(), h.ServeHTTP)
+	if err := http.ListenAndServe(h.HealthCheckURL.Host, serveMux); err != nil && err != http.ErrServerClosed {
+		klog.Fatalf("failed to start health check server, err: %+v", err)
+	}
+}
+
+func (h *HealthZ) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	klog.V(5).Infof("Started health check")
+	ctx, cancel := context.WithTimeout(context.Background(), h.RPCTimeout)
+	defer cancel()
+
+	conn, err := h.dialUnixSocket()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	defer conn.Close()
+
+	// create the kms client
+	kmsClient := pb.NewKeyManagementServiceClient(conn)
+	// check version response against KMS-Plugin's gRPC endpoint.
+	err = h.checkRPC(ctx, kmsClient)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	// check the configured keyvault, key, key version and permissions are still
+	// valid to encrypt and decrypt with test data.
+	enc, err := h.KMSServer.Encrypt(ctx, &pb.EncryptRequest{Plain: []byte(healthCheckPlainText)})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	dec, err := h.KMSServer.Decrypt(ctx, &pb.DecryptRequest{Cipher: enc.Cipher})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if string(dec.Plain) != healthCheckPlainText {
+		http.Error(w, "plain text mismatch after decryption", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+	klog.V(5).Infof("Completed health check")
+}
+
+// checkRPC initiates a grpc request to validate the socket is responding
+// sends a KMS VersionRequest and checks if the VersionResponse is valid.
+func (h *HealthZ) checkRPC(ctx context.Context, client pb.KeyManagementServiceClient) error {
+	v, err := client.Version(ctx, &pb.VersionRequest{})
+	if err != nil {
+		return err
+	}
+	if v.Version != version.APIVersion || v.RuntimeName != version.Runtime || v.RuntimeVersion != version.BuildVersion {
+		return fmt.Errorf("failed to get correct version response")
+	}
+	return nil
+}
+
+func (h *HealthZ) dialUnixSocket() (*grpc.ClientConn, error) {
+	return grpc.Dial(
+		h.UnixSocketPath,
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(func(ctx context.Context, target string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", target)
+		}),
+	)
+}

--- a/pkg/plugin/healthz_test.go
+++ b/pkg/plugin/healthz_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	mockkeyvault "github.com/Azure/kubernetes-kms/pkg/plugin/mock_keyvault"
+
+	"google.golang.org/grpc"
+	pb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
+)
+
+func TestServe(t *testing.T) {
+	tests := []struct {
+		desc                   string
+		setEncryptResponse     string
+		setDecryptResponse     string
+		setEncryptError        error
+		setDecryptError        error
+		expectedHTTPStatusCode int
+	}{
+		{
+			desc:                   "failed to encrypt in health check",
+			setEncryptResponse:     "",
+			setEncryptError:        fmt.Errorf("failed to encrypt"),
+			expectedHTTPStatusCode: http.StatusInternalServerError,
+		},
+		{
+			desc:                   "failed to decrypt in health check",
+			setEncryptResponse:     "",
+			setEncryptError:        nil,
+			setDecryptResponse:     "",
+			setDecryptError:        fmt.Errorf("failed to decrypt"),
+			expectedHTTPStatusCode: http.StatusInternalServerError,
+		},
+		{
+			desc:                   "encrypt-decrypt mismatch",
+			setEncryptResponse:     "bar",
+			setEncryptError:        nil,
+			setDecryptResponse:     "foo",
+			setDecryptError:        nil,
+			expectedHTTPStatusCode: http.StatusInternalServerError,
+		},
+		{
+			desc:                   "successful health check",
+			setEncryptResponse:     "bar",
+			setDecryptResponse:     "healthcheck",
+			expectedHTTPStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			socketPath := fmt.Sprintf("%s/kms.sock", getTempTestDir(t))
+			defer os.Remove(socketPath)
+
+			fakeKMSServer, mockKVClient, err := setupFakeKMSServer(socketPath)
+			if err != nil {
+				t.Fatalf("failed to create fake kms server, err: %+v", err)
+			}
+
+			mockKVClient.SetEncryptResponse([]byte(test.setEncryptResponse), test.setEncryptError)
+			mockKVClient.SetDecryptResponse([]byte(test.setDecryptResponse), test.setDecryptError)
+
+			healthz := &HealthZ{
+				KMSServer:      fakeKMSServer,
+				UnixSocketPath: socketPath,
+				RPCTimeout:     20 * time.Second,
+				HealthCheckURL: &url.URL{
+					Scheme: "http",
+					Host:   net.JoinHostPort("localhost", "8080"),
+					Path:   "/healthz",
+				},
+			}
+
+			server := httptest.NewServer(healthz)
+			defer server.Close()
+
+			respCode, body := doHealthCheck(t, server.URL)
+			if respCode != test.expectedHTTPStatusCode {
+				t.Fatalf("expected status code: %v, got: %v", test.expectedHTTPStatusCode, respCode)
+			}
+			if test.expectedHTTPStatusCode == http.StatusOK && string(body) != "ok" {
+				t.Fatalf("expected response body to be 'ok', got: %s", string(body))
+			}
+		})
+	}
+}
+
+func TestCheckRPC(t *testing.T) {
+	socketPath := fmt.Sprintf("%s/kms.sock", getTempTestDir(t))
+	defer os.Remove(socketPath)
+
+	fakeKMSServer, _, err := setupFakeKMSServer(socketPath)
+	if err != nil {
+		t.Fatalf("failed to create fake kms server, err: %+v", err)
+	}
+	healthz := &HealthZ{
+		KMSServer:      fakeKMSServer,
+		UnixSocketPath: socketPath,
+	}
+
+	conn, err := healthz.dialUnixSocket()
+	if err != nil {
+		t.Fatalf("failed to create connection, err: %+v", err)
+	}
+	err = healthz.checkRPC(context.TODO(), pb.NewKeyManagementServiceClient(conn))
+	if err != nil {
+		t.Fatalf("expected err to be nil, got: %+v", err)
+	}
+}
+
+func getTempTestDir(t *testing.T) string {
+	tmpDir, err := ioutil.TempDir("", "ut")
+	if err != nil {
+		t.Fatalf("expected err to be nil, got: %+v", err)
+	}
+	return tmpDir
+}
+
+func setupFakeKMSServer(socketPath string) (*KeyManagementServiceServer, *mockkeyvault.KeyVaultClient, error) {
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	kvClient := &mockkeyvault.KeyVaultClient{}
+	fakeKMSServer := &KeyManagementServiceServer{kvClient: kvClient}
+	s := grpc.NewServer()
+	pb.RegisterKeyManagementServiceServer(s, fakeKMSServer)
+	go s.Serve(listener)
+
+	return fakeKMSServer, kvClient, nil
+}
+
+func doHealthCheck(t *testing.T, url string) (int, []byte) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("failed to create new http request, err: %+v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to invoke http request, err: %+v", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body, err: %+v", err)
+	}
+	return resp.StatusCode, body
+}

--- a/tests/e2e/kms.yaml
+++ b/tests/e2e/kms.yaml
@@ -17,7 +17,16 @@ spec:
         - --keyvault-name=${KEYVAULT_NAME}
         - --key-name=${KEY_NAME}
         - --key-version=${KEY_VERSION}
-        - -v=2
+        - -v=5
+      ports:
+        - containerPort: 8787
+          protocol: TCP
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 8787
+        failureThreshold: 2
+        periodSeconds: 10
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
- Adds `healthz` check for kms plugin
- `kube-apiserver` performs a health check on the kms plugin every 20s
   - This checks encrypt and decrypt 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/kubernetes-kms/issues/62

**Notes for Reviewers**:
