### PR TITLE
ci: add nightly pipeline and fix CVE-2021-24032

### DIFF
--- a/.pipelines/nightly.yml
+++ b/.pipelines/nightly.yml
@@ -1,0 +1,16 @@
+trigger: none
+
+schedules:
+  - cron: "0 0 * * *"
+    always: true
+    displayName: "Nightly Build & Test"
+    branches:
+      include:
+        - master
+
+pool:
+  vmImage: ubuntu-latest
+
+jobs:
+  - template: unit-tests-template.yml
+  - template: e2e-kind-template.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.4.0
+# upgrading libzstd1 due to CVE-2021-24032
+RUN clean-install libzstd1
 COPY ./_output/kubernetes-kms /bin/
 
 ENTRYPOINT [ "/bin/kubernetes-kms" ]


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
- Adds nightly test pipeline
- Fixes CVE-2021-24032

```bash
e2e/kubernetes-kms:test (debian 10.7)
=====================================
Total: 1 (MEDIUM: 1, HIGH: 0, CRITICAL: 0)

+----------+------------------+----------+-------------------+----------------------+--------------------------------+------------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |    FIXED VERSION     |             TITLE              |                URL                 |
+----------+------------------+----------+-------------------+----------------------+--------------------------------+------------------------------------+
| libzstd1 | CVE-2021-24032   | MEDIUM   | 1.3.8+dfsg-3      | 1.3.8+dfsg-3+deb10u2 | zstd: Race condition           | avd.aquasec.com/nvd/cve-2021-24032 |
|          |                  |          |                   |                      | allows attacker to access      |                                    |
|          |                  |          |                   |                      | world-readable destination     |                                    |
|          |                  |          |                   |                      | file                           |                                    |
+----------+------------------+----------+-------------------+----------------------+--------------------------------+------------------------------------+
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
