### PR TITLE
fix: handles key vault name with double quotes.

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,7 +32,7 @@ var (
 	keyName       = flag.String("key-name", "", "Azure Key Vault KMS key name")
 	keyVersion    = flag.String("key-version", "", "Azure Key Vault KMS key version")
 	logFormatJSON = flag.Bool("log-format-json", false, "set log formatter to json")
-	// TODO change this to follow the hyphen format. DEPRECATE this flag and introduce the new flag
+	// TODO change this to follow the hyphen format. DEPRECATE this flag and introduce the new flag 
 	configFilePath = flag.String("configFilePath", "/etc/kubernetes/azure.json", "Path for Azure Cloud Provider config file")
 	versionInfo    = flag.Bool("version", false, "Prints the version information")
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,7 +32,7 @@ var (
 	keyName       = flag.String("key-name", "", "Azure Key Vault KMS key name")
 	keyVersion    = flag.String("key-version", "", "Azure Key Vault KMS key version")
 	logFormatJSON = flag.Bool("log-format-json", false, "set log formatter to json")
-	// TODO change this to follow the hyphen format. DEPRECATE this flag and introduce the new flag 
+	// TODO change this to follow the hyphen format. DEPRECATE this flag and introduce the new flag
 	configFilePath = flag.String("configFilePath", "/etc/kubernetes/azure.json", "Path for Azure Cloud Provider config file")
 	versionInfo    = flag.Bool("version", false, "Prints the version information")
 

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -73,7 +73,7 @@ This guide demonstrates steps required to enable the KMS Plugin for Key Vault in
         imagePullPolicy: IfNotPresent
         args:
           - --listen-addr=unix:///opt/azurekms.socket             # [OPTIONAL] gRPC listen address. Default is unix:///opt/azurekms.socket
-          - --keyvault-name=${KV_NAME}                            # [REQUIRED] Name of the keyvault
+          - --keyvault-name=${KV_NAME}                            # [REQUIRED] Name of the keyvault. Must match criteria specified at https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
           - --key-name=${KEY_NAME}                                # [REQUIRED] Name of the keyvault key used for encrypt/decrypt
           - --key-version=${KEY_VERSION}                          # [REQUIRED] Version of the key to use
           - --log-format-json=false                               # [OPTIONAL] Set log formatter to json. Default is false.

--- a/pkg/plugin/keyvault.go
+++ b/pkg/plugin/keyvault.go
@@ -10,10 +10,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/Azure/kubernetes-kms/pkg/auth"
 	"github.com/Azure/kubernetes-kms/pkg/config"
+	"github.com/Azure/kubernetes-kms/pkg/utils"
 	"github.com/Azure/kubernetes-kms/pkg/version"
 
 	kv "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
@@ -39,6 +39,11 @@ type keyVaultClient struct {
 
 // NewKeyVaultClient returns a new key vault client to use for kms operations
 func newKeyVaultClient(config *config.AzureConfig, vaultName, keyName, keyVersion string) (*keyVaultClient, error) {
+	//Sanitize vaultName, keyName, keyVersion. (https://github.com/Azure/kubernetes-kms/issues/85)
+	vaultName = utils.SanitizeString(vaultName)
+	keyName = utils.SanitizeString(keyName)
+	keyVersion = utils.SanitizeString(keyVersion)
+
 	// this should be the case for bring your own key, clusters bootstrapped with
 	// aks-engine or aks and standalone kms plugin deployments
 	if len(vaultName) == 0 || len(keyName) == 0 || len(keyVersion) == 0 {
@@ -116,9 +121,6 @@ func getVaultURL(vaultName string, azureEnvironment *azure.Environment) (vaultUR
 	if len(vaultName) < 3 || len(vaultName) > 24 {
 		return nil, fmt.Errorf("invalid vault name: %q, must be between 3 and 24 chars", vaultName)
 	}
-
-	//Trim quotes from vault name. https://github.com/Azure/kubernetes-kms/issues/85
-	vaultName = strings.Trim(vaultName, "\"")
 
 	// See docs for validation spec: https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#objects-identifiers-and-versioning
 	isValid := regexp.MustCompile(`^[-A-Za-z0-9]+$`).MatchString

--- a/pkg/plugin/keyvault.go
+++ b/pkg/plugin/keyvault.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/Azure/kubernetes-kms/pkg/auth"
 	"github.com/Azure/kubernetes-kms/pkg/config"
@@ -115,6 +116,10 @@ func getVaultURL(vaultName string, azureEnvironment *azure.Environment) (vaultUR
 	if len(vaultName) < 3 || len(vaultName) > 24 {
 		return nil, fmt.Errorf("invalid vault name: %q, must be between 3 and 24 chars", vaultName)
 	}
+
+	//Trim quotes from vault name. https://github.com/Azure/kubernetes-kms/issues/85
+	vaultName = strings.Trim(vaultName, "\"")
+
 	// See docs for validation spec: https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#objects-identifiers-and-versioning
 	isValid := regexp.MustCompile(`^[-A-Za-z0-9]+$`).MatchString
 	if !isValid(vaultName) {

--- a/pkg/plugin/keyvault_test.go
+++ b/pkg/plugin/keyvault_test.go
@@ -106,6 +106,11 @@ func TestGetVaultURL(t *testing.T) {
 			vaultName:   "testkv",
 			expectedErr: false,
 		},
+		{
+			desc:        "vault name with double quotes",
+			vaultName:   "\"testkv\"",
+			expectedErr: false,
+		},
 	}
 
 	for idx, test := range tests {
@@ -118,7 +123,7 @@ func TestGetVaultURL(t *testing.T) {
 			if test.expectedErr && err == nil || !test.expectedErr && err != nil {
 				t.Fatalf("expected error: %v, got error: %v", test.expectedErr, err)
 			}
-			expectedURL := "https://" + test.vaultName + "." + vaultDNSSuffix[idx] + "/"
+			expectedURL := "https://" + strings.Trim(test.vaultName, "\"") + "." + vaultDNSSuffix[idx] + "/"
 			if !test.expectedErr && expectedURL != *vaultURL {
 				t.Fatalf("expected vault url: %s, got: %s", expectedURL, *vaultURL)
 			}

--- a/pkg/plugin/keyvault_test.go
+++ b/pkg/plugin/keyvault_test.go
@@ -57,6 +57,14 @@ func TestNewKeyVaultClient(t *testing.T) {
 			keyVersion:  "262067a9e8ba401aa8a746c5f1a7e147",
 			expectedErr: false,
 		},
+		{
+			desc:        "no error with double quotes",
+			config:      &config.AzureConfig{ClientID: "clientid", ClientSecret: "clientsecret"},
+			vaultName:   "\"testkv\"",
+			keyName:     "\"key1\"",
+			keyVersion:  "\"262067a9e8ba401aa8a746c5f1a7e147\"",
+			expectedErr: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -104,11 +112,6 @@ func TestGetVaultURL(t *testing.T) {
 		{
 			desc:        "valid vault name in public cloud",
 			vaultName:   "testkv",
-			expectedErr: false,
-		},
-		{
-			desc:        "vault name with double quotes",
-			vaultName:   "\"testkv\"",
 			expectedErr: false,
 		},
 	}

--- a/pkg/utils/sanitize.go
+++ b/pkg/utils/sanitize.go
@@ -1,0 +1,8 @@
+package utils
+
+import "strings"
+
+// SanitizeString returns a string that does not have white spaces and double quotes
+func SanitizeString(s string) string {
+	return strings.TrimSpace(strings.Trim(strings.TrimSpace(s), "\""))
+}

--- a/pkg/utils/sanitize_test.go
+++ b/pkg/utils/sanitize_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import "testing"
+
+func TestSanitizeString(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          string
+		expectedOutput string
+	}{
+		{
+			name:           "With_White_Spaces",
+			input:          " hello ",
+			expectedOutput: "hello",
+		},
+		{
+			name:           "With_Double_Quotes",
+			input:          "\"hello\"",
+			expectedOutput: "hello",
+		},
+		{
+			name:           "With_White_Spaces_And_Double_Quotes",
+			input:          " \"hello\" ",
+			expectedOutput: "hello",
+		},
+		{
+			name:           "With_Double_Quotes_And_White_Spaces",
+			input:          "\" hello \"",
+			expectedOutput: "hello",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			sanitizedString := SanitizeString(testCase.input)
+
+			if sanitizedString != testCase.expectedOutput {
+				t.Fatalf("expected output: '%s', found: '%s'", testCase.expectedOutput, sanitizedString)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
Removes double quotes from keyvault name.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/kubernetes-kms/issues/85

**Notes for Reviewers**:
