### PR TITLE
fix: deprecates configFilePath

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,8 +32,9 @@ var (
 	keyName       = flag.String("key-name", "", "Azure Key Vault KMS key name")
 	keyVersion    = flag.String("key-version", "", "Azure Key Vault KMS key version")
 	logFormatJSON = flag.Bool("log-format-json", false, "set log formatter to json")
-	// TODO change this to follow the hyphen format. DEPRECATE this flag and introduce the new flag
-	configFilePath = flag.String("configFilePath", "/etc/kubernetes/azure.json", "Path for Azure Cloud Provider config file")
+	// TODO remove this flag in future release.
+	_              = flag.String("configFilePath", "/etc/kubernetes/azure.json", "[DEPRECATED] Path for Azure Cloud Provider config file")
+	configFilePath = flag.String("config-file-path", "/etc/kubernetes/azure.json", "Path for Azure Cloud Provider config file")
 	versionInfo    = flag.Bool("version", false, "Prints the version information")
 
 	healthzPort    = flag.Int("healthz-port", 8787, "port for health check")


### PR DESCRIPTION
Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
Deprecates `configFilePath` and introduces hyphen separated `config-file-path`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/kubernetes-kms/issues/101

**Notes for Reviewers**:
