### PR TITLE
Add proxy mode

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,6 +43,10 @@ var (
 	healthzTimeout = flag.Duration("healthz-timeout", 20*time.Second, "RPC timeout for health check")
 	metricsBackend = flag.String("metrics-backend", "prometheus", "Backend used for metrics")
 	metricsAddress = flag.String("metrics-addr", "8095", "The address the metric endpoint binds to")
+
+	proxyMode    = flag.Bool("proxy-mode", false, "Proxy mode")
+	proxyAddress = flag.String("proxy-address", "", "proxy address")
+	proxyPort    = flag.Int("proxy-port", 7788, "port for proxy")
 )
 
 func main() {
@@ -68,7 +72,7 @@ func main() {
 	}
 
 	klog.InfoS("Starting KeyManagementServiceServer service", "version", version.BuildVersion, "buildDate", version.BuildDate)
-	kmsServer, err := plugin.New(ctx, *configFilePath, *keyvaultName, *keyName, *keyVersion)
+	kmsServer, err := plugin.New(ctx, *configFilePath, *keyvaultName, *keyName, *keyVersion, *proxyMode, *proxyAddress, *proxyPort)
 	if err != nil {
 		klog.Fatalf("failed to create server, error: %v", err)
 	}

--- a/pkg/plugin/keyvault.go
+++ b/pkg/plugin/keyvault.go
@@ -38,7 +38,7 @@ type keyVaultClient struct {
 }
 
 // NewKeyVaultClient returns a new key vault client to use for kms operations
-func newKeyVaultClient(config *config.AzureConfig, vaultName, keyName, keyVersion string) (*keyVaultClient, error) {
+func newKeyVaultClient(config *config.AzureConfig, vaultName, keyName, keyVersion string, proxyMode bool, proxyAddress string, proxyPort int) (*keyVaultClient, error) {
 	// Sanitize vaultName, keyName, keyVersion. (https://github.com/Azure/kubernetes-kms/issues/85)
 	vaultName = utils.SanitizeString(vaultName)
 	keyName = utils.SanitizeString(keyName)
@@ -58,7 +58,11 @@ func newKeyVaultClient(config *config.AzureConfig, vaultName, keyName, keyVersio
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse cloud environment: %s, error: %+v", config.Cloud, err)
 	}
-	token, err := auth.GetKeyvaultToken(config, env)
+	if proxyMode {
+		env.ActiveDirectoryEndpoint = fmt.Sprintf("http://%s:%d/AzureActiveDirectory", proxyAddress, proxyPort)
+	}
+
+	token, err := auth.GetKeyvaultToken(config, env, proxyMode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get key vault token, error: %+v", err)
 	}
@@ -69,7 +73,13 @@ func newKeyVaultClient(config *config.AzureConfig, vaultName, keyName, keyVersio
 		return nil, fmt.Errorf("failed to get vault url, error: %+v", err)
 	}
 
-	klog.InfoS("using kms key for encrypt/decrypt", "vaultName", vaultName, "keyName", keyName, "keyVersion", keyVersion)
+	klog.InfoS("using kms key for encrypt/decrypt", "vaultURL", *vaultURL, "keyName", keyName, "keyVersion", keyVersion)
+
+	if proxyMode {
+		proxyEndpoint := fmt.Sprintf("http://%s:%d/KeyVault/%s", proxyAddress, proxyPort, (*vaultURL)[8:])
+		klog.InfoS("proxy url", "url", proxyEndpoint)
+		vaultURL = &proxyEndpoint
+	}
 
 	client := &keyVaultClient{
 		baseClient:       kvClient,

--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -24,12 +24,12 @@ type KeyManagementServiceServer struct {
 }
 
 // New creates an instance of the KMS Service Server.
-func New(ctx context.Context, configFilePath, vaultName, keyName, keyVersion string) (*KeyManagementServiceServer, error) {
+func New(ctx context.Context, configFilePath, vaultName, keyName, keyVersion string, proxyMode bool, proxyAddress string, proxyPort int) (*KeyManagementServiceServer, error) {
 	cfg, err := config.GetAzureConfig(configFilePath)
 	if err != nil {
 		return nil, err
 	}
-	kvClient, err := newKeyVaultClient(cfg, vaultName, keyName, keyVersion)
+	kvClient, err := newKeyVaultClient(cfg, vaultName, keyName, keyVersion, proxyMode, proxyAddress, proxyPort)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	netProtocol      = "unix"
-	pathToUnixSocket = "/opt/azurekms.sock"
+	pathToUnixSocket = "/opt/azurekms.socket"
 	version          = "v1beta1"
 )
 


### PR DESCRIPTION
<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->

In some cases, the KMS plugin may not access Key Vault. This PR is to add a proxy mode so that the requests can be forwarded to the proxy, then the proxy can forward the requests to Key Vault.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

N/A

**Notes for Reviewers**:
