### PR TITLE
Support proxy mode in case kms-plugin can not access key vault

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,6 +43,10 @@ var (
 	healthzTimeout = flag.Duration("healthz-timeout", 20*time.Second, "RPC timeout for health check")
 	metricsBackend = flag.String("metrics-backend", "prometheus", "Backend used for metrics")
 	metricsAddress = flag.String("metrics-addr", "8095", "The address the metric endpoint binds to")
+
+	proxyMode    = flag.Bool("proxy-mode", false, "Proxy mode")
+	proxyAddress = flag.String("proxy-address", "", "proxy address")
+	proxyPort    = flag.Int("proxy-port", 7788, "port for proxy")
 )
 
 func main() {
@@ -68,7 +72,7 @@ func main() {
 	}
 
 	klog.InfoS("Starting KeyManagementServiceServer service", "version", version.BuildVersion, "buildDate", version.BuildDate)
-	kmsServer, err := plugin.New(ctx, *configFilePath, *keyvaultName, *keyName, *keyVersion)
+	kmsServer, err := plugin.New(ctx, *configFilePath, *keyvaultName, *keyName, *keyVersion, *proxyMode, *proxyAddress, *proxyPort)
 	if err != nil {
 		klog.Fatalf("failed to create server, error: %v", err)
 	}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package consts
+
+const (
+	// In proxy mode, the header is added into the requests from kms-plugin.
+	// The proxy will check the header and forward the request to different destinations.
+	// e.g. When the value of the header "x-azure-proxy-target" is "KeyVault", the request
+	// is forwared to Azure Key Vault by the proxy.
+	RequestHeaderTargetType        = "x-azure-proxy-target"
+	TargetTypeAzureActiveDirectory = "AzureActiveDirectory"
+	TargetTypeKeyVault             = "KeyVault"
+)

--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -24,12 +24,12 @@ type KeyManagementServiceServer struct {
 }
 
 // New creates an instance of the KMS Service Server.
-func New(ctx context.Context, configFilePath, vaultName, keyName, keyVersion string) (*KeyManagementServiceServer, error) {
+func New(ctx context.Context, configFilePath, vaultName, keyName, keyVersion string, proxyMode bool, proxyAddress string, proxyPort int) (*KeyManagementServiceServer, error) {
 	cfg, err := config.GetAzureConfig(configFilePath)
 	if err != nil {
 		return nil, err
 	}
-	kvClient, err := newKeyVaultClient(cfg, vaultName, keyName, keyVersion)
+	kvClient, err := newKeyVaultClient(cfg, vaultName, keyName, keyVersion, proxyMode, proxyAddress, proxyPort)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->

This PR is to support KMS Plugin in AKS. The KMS Plugin is a sidecar of kube-apiserver pod. Due to security reasons, the KMS plugin may not access Key Vault. This PR will add a proxy mode so that the requests can be forwarded to the proxy, then the proxy can forward the requests to Key Vault.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

N/A

**Notes for Reviewers**:

Needs to release a new image 