### PR TITLE
chore: upgrade to go 1.18

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,15 +9,14 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - maligned
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - structcheck
     - unused

--- a/.pipelines/templates/e2e-kind-template.yml
+++ b/.pipelines/templates/e2e-kind-template.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.17
+          version: 1.18
 
       - script: make e2e-install-prerequisites
         displayName: "Install e2e test prerequisites"

--- a/.pipelines/templates/e2e-upgrade-template.yml
+++ b/.pipelines/templates/e2e-upgrade-template.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.17
+          version: 1.18
 
       - script: make e2e-install-prerequisites
         displayName: "Install e2e test prerequisites"

--- a/.pipelines/templates/unit-tests-template.yml
+++ b/.pipelines/templates/unit-tests-template.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.17
+          version: 1.18
       - script: make lint
         displayName: Run lint
       - script: make unit-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-bullseye as builder
+FROM golang:1.18-bullseye as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kubernetes-kms
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Azure/azure-sdk-for-go v62.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -105,7 +105,6 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kubernetes-kms/tools
 
-go 1.17
+go 1.18
 
 require github.com/golangci/golangci-lint v1.44.2
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
- Upgrades to go 1.18
- Removes deprecated linters (`golint` replaced with `revive`, `maligned` removed)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
