### PR TITLE
chore: use structured logging and update imports order

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -41,7 +41,7 @@ func GetServicePrincipalToken(config *config.AzureConfig, aadEndpoint, resource 
 	}
 
 	if config.UseManagedIdentityExtension {
-		klog.V(2).Infof("using managed identity extension to retrieve access token")
+		klog.V(2).Info("using managed identity extension to retrieve access token")
 		msiEndpoint, err := adal.GetMSIVMEndpoint()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get managed service identity endpoint, error: %v", err)
@@ -79,7 +79,7 @@ func GetServicePrincipalToken(config *config.AzureConfig, aadEndpoint, resource 
 	}
 
 	if len(config.AADClientCertPath) > 0 && len(config.AADClientCertPassword) > 0 {
-		klog.V(2).Infof("using jwt client_assertion (client_cert+client_private_key) to retrieve access token")
+		klog.V(2).Info("using jwt client_assertion (client_cert+client_private_key) to retrieve access token")
 		certData, err := os.ReadFile(config.AADClientCertPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read client certificate from file %s, error: %v", config.AADClientCertPath, err)

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/kubernetes-kms/pkg/config"
+
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/kubernetes-kms/pkg/config"
 )
 
 func TestParseAzureEnvironment(t *testing.T) {

--- a/pkg/config/azure_config.go
+++ b/pkg/config/azure_config.go
@@ -24,7 +24,7 @@ type AzureConfig struct {
 func GetAzureConfig(configFile string) (config *AzureConfig, err error) {
 	cfg := AzureConfig{}
 
-	klog.V(5).Infof("populating AzureConfig from %s", configFile)
+	klog.V(5).InfoS("populating AzureConfig from config file", "configFile", configFile)
 	bytes, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config file %s, error: %+v", configFile, err)

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -14,7 +14,7 @@ const (
 // InitMetricsExporter initializes new exporter
 func InitMetricsExporter(metricsBackend, metricsAddress string) error {
 	exporter := strings.ToLower(metricsBackend)
-	klog.Infof("metrics backend: %s", exporter)
+	klog.InfoS("metrics backend", "exporter", exporter)
 
 	switch exporter {
 	// Prometheus is the only exporter supported for now

--- a/pkg/metrics/prometheus_exporter.go
+++ b/pkg/metrics/prometheus_exporter.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"go.opentelemetry.io/otel/exporters/metric/prometheus"
 	"k8s.io/klog/v2"
@@ -25,7 +26,8 @@ func initPrometheusExporter(metricsAddress string) error {
 	http.HandleFunc(fmt.Sprintf("/%s", metricsEndpoint), exporter.ServeHTTP)
 	go func() {
 		if err := http.ListenAndServe(fmt.Sprintf(":%s", metricsAddress), nil); err != nil {
-			klog.Fatalf("Failed to register prometheus endpoint - %v", err)
+			klog.ErrorS(err, "failed to register prometheus endpoint", "metricsAddress", metricsAddress)
+			os.Exit(1)
 		}
 	}()
 

--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -74,13 +74,13 @@ func (s *KeyManagementServiceServer) Encrypt(ctx context.Context, request *k8spb
 		s.reporter.ReportRequest(ctx, metrics.EncryptOperationTypeValue, status, time.Since(start).Seconds(), errors)
 	}()
 
-	klog.V(2).Infof("encrypt request started")
+	klog.V(2).Info("encrypt request started")
 	cipher, err := s.kvClient.Encrypt(ctx, request.Plain)
 	if err != nil {
 		klog.ErrorS(err, "failed to encrypt")
 		return &k8spb.EncryptResponse{}, err
 	}
-	klog.V(2).Infof("encrypt request complete")
+	klog.V(2).Info("encrypt request complete")
 	return &k8spb.EncryptResponse{Cipher: cipher}, nil
 }
 
@@ -99,12 +99,12 @@ func (s *KeyManagementServiceServer) Decrypt(ctx context.Context, request *k8spb
 		s.reporter.ReportRequest(ctx, metrics.DecryptOperationTypeValue, status, time.Since(start).Seconds(), errors)
 	}()
 
-	klog.V(2).Infof("decrypt request started")
+	klog.V(2).Info("decrypt request started")
 	plain, err := s.kvClient.Decrypt(ctx, request.Cipher)
 	if err != nil {
 		klog.ErrorS(err, "failed to decrypt")
 		return &k8spb.DecryptResponse{}, err
 	}
-	klog.V(2).Infof("decrypt request complete")
+	klog.V(2).Info("decrypt request complete")
 	return &k8spb.DecryptResponse{Plain: plain}, nil
 }

--- a/pkg/plugin/server_test.go
+++ b/pkg/plugin/server_test.go
@@ -10,11 +10,11 @@ import (
 	"fmt"
 	"testing"
 
-	k8spb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
-
 	"github.com/Azure/kubernetes-kms/pkg/metrics"
 	mockkeyvault "github.com/Azure/kubernetes-kms/pkg/plugin/mock_keyvault"
 	"github.com/Azure/kubernetes-kms/pkg/version"
+
+	k8spb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
 )
 
 func TestEncrypt(t *testing.T) {

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Azure/kubernetes-kms/pkg/metrics"
+
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 )
@@ -38,7 +39,7 @@ func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 		reporter.ReportRequest(ctx, fmt.Sprintf("%s_%s", metrics.GrpcOperationTypeValue, getGRPCMethodName(info.FullMethod)), status, time.Since(start).Seconds(), errors)
 	}()
 
-	klog.V(5).Infof("GRPC call: %s", info.FullMethod)
+	klog.V(5).InfoS("GRPC call", "method", info.FullMethod)
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.ErrorS(err, "GRPC request error")


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
- Updates all the logs to use structured logging with klog
- Replaced `Fatalf` with `ErrorS` followed by `os.Exit(1)` as recommended in https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#change-log-functions-to-structured-equivalent
- Fix imports structure across all the packages. The format used in this project is
  ```bash
   import (
     std packages
    
     internal packages

     external packages
   )
   ```


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
