### PR TITLE
remove aks engine instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ From the Kubernetes documentation on [Encrypting Secret Data at Rest]:
 
 Azure Kubernetes Service ([AKS]) creates managed, supported Kubernetes clusters on Azure.
 
-For more information about K8s secrets in AKS follow this [doc](https://docs.microsoft.com/en-us/azure/aks/concepts-security#kubernetes-secrets).
+To try out the KMS plugin for KeyValut on AKS, follow this [doc](https://docs.microsoft.com/en-us/azure/aks/use-kms-etcd-encryption).
 
-AKS does encrypt secrets at rest, but keys are managed by the service and users cannot bring their own.
+AKS does encrypt secrets at rest by default, but in that case keys are managed by the service and users cannot bring their own.
 
 ### Setting up KMS Plugin manually
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ From the Kubernetes documentation on [Encrypting Secret Data at Rest]:
 
 Azure Kubernetes Service ([AKS]) creates managed, supported Kubernetes clusters on Azure.
 
-To try out the KMS plugin for KeyValut on AKS, follow this [doc](https://docs.microsoft.com/en-us/azure/aks/use-kms-etcd-encryption).
+To try out the KMS plugin for Key Vault on AKS, follow this [doc](https://docs.microsoft.com/en-us/azure/aks/use-kms-etcd-encryption).
 
 AKS does encrypt secrets at rest by default, but in that case keys are managed by the service and users cannot bring their own.
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ From the Kubernetes documentation on [Encrypting Secret Data at Rest]:
 
 💡 Make sure you have a Kubernetes cluster version 1.10 or later, the minimum version that is supported by KMS Plugin for Key Vault.
 
-### 🎁 aks-engine
-
-[AKS Engine] creates customized Kubernetes clusters on Azure.
-
-Follow the AKS Engine documentation about [Azure Key Vault Data Encryption] and refer to the [example cluster configuration] to create a Kubernetes cluster with KMS Plugin for Key Vault automatically configured. Once the cluster is running, there will be an Azure Key Vault containing a new key in the same resource group as the cluster.
-
 ### Azure Kubernetes Service (AKS)
 
 Azure Kubernetes Service ([AKS]) creates managed, supported Kubernetes clusters on Azure.

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -41,9 +41,6 @@ This guide demonstrates steps required to enable the KMS Plugin for Key Vault in
   | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
   | AKS cluster with service principal               | `az aks show -g <AKSResourceGroup> -n <AKSClusterName> --query servicePrincipalProfile.clientId -otsv`                                                                        |
   | AKS cluster with managed identity                | `az aks show -g <AKSResourceGroup> -n <AKSClusterName> --query identityProfile.kubeletidentity.clientId -otsv`                                                                |
-  | aks-engine cluster with service principal        | Use the client ID of the service principal defined in the API model                                                                                                           |
-  | aks-engine cluster with system-assigned identity | `az <vm\|vmss> identity show -g <NodeResourceGroup> -n <VM\|VMSS Name> --query principalId -otsv`                                                                             |
-  | aks-engine cluster with user-assigned identity   | `az <vm\|vmss> identity show -g <NodeResourceGroup> -n <VM\|VMSS Name> --query userAssignedIdentities -otsv`, then copy the `clientID` of the selected user-assigned identity |
 
   Assign the following permissions:
 


### PR DESCRIPTION
**Reason for Change**:
AKS engine is being deprecated, this is a docs change to remove the reference to it from the README.


**Issue Fixed**:
fixes #136 
