### PR TITLE
ci: enable tests with kubernetes v1.26 

### DIFF
--- a/.pipelines/templates/e2e-kind-template.yml
+++ b/.pipelines/templates/e2e-kind-template.yml
@@ -25,8 +25,6 @@ jobs:
       - group: kubernetes-kms
     strategy:
       matrix:
-        kind_v1_22_13:
-          KUBERNETES_VERSION: v1.22.13
         kind_v1_23_10:
           KUBERNETES_VERSION: v1.23.10
         kind_v1_24_4:

--- a/.pipelines/templates/e2e-kind-template.yml
+++ b/.pipelines/templates/e2e-kind-template.yml
@@ -33,6 +33,8 @@ jobs:
           KUBERNETES_VERSION: v1.24.4
         kind_v1_25_0:
           KUBERNETES_VERSION: v1.25.0
+        kind_v1_26_0:
+          KUBERNETES_VERSION: v1.26.0
     steps:
       - task: GoTool@0
         inputs:

--- a/.pipelines/templates/e2e-kind-template.yml
+++ b/.pipelines/templates/e2e-kind-template.yml
@@ -25,12 +25,12 @@ jobs:
       - group: kubernetes-kms
     strategy:
       matrix:
-        kind_v1_23_10:
-          KUBERNETES_VERSION: v1.23.10
-        kind_v1_24_4:
-          KUBERNETES_VERSION: v1.24.4
-        kind_v1_25_0:
-          KUBERNETES_VERSION: v1.25.0
+        kind_v1_23_13:
+          KUBERNETES_VERSION: v1.23.13
+        kind_v1_24_7:
+          KUBERNETES_VERSION: v1.24.7
+        kind_v1_25_3:
+          KUBERNETES_VERSION: v1.25.3
         kind_v1_26_0:
           KUBERNETES_VERSION: v1.26.0
     steps:


### PR DESCRIPTION
<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
- enable tests with kubernetes v1.26 
- remove kubernetes version 1.22 (EOL)
- update kubernetes versions for supported releases

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
