### PR TITLE
chore: remove manual gettext/envsubst install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,6 @@ e2e-install-prerequisites:
 	curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv kubectl /usr/local/bin/
 	# Download and install bats
 	curl -sSLO https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz && tar -zxvf v${BATS_VERSION}.tar.gz && sudo bash bats-core-${BATS_VERSION}/install.sh /usr/local
-	# Install envsubst
-	sudo tdnf install -y gettext
 
 .PHONY: install-soak-prerequisites
 install-soak-prerequisites: e2e-install-prerequisites


### PR DESCRIPTION
<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
We have updated mariner pools to install this package (gettext) during preprovison. Not longer need to manual install this

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Notes for Reviewers**:
