### PR TITLE
chore: use `dl.k8s.io` instead of hardcoded url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ e2e-install-prerequisites:
 	# Download and install kind
 	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output kind && chmod +x kind && sudo mv kind /usr/local/bin/
 	# Download and install kubectl
-	curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv kubectl /usr/local/bin/
+	curl -LO https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv kubectl /usr/local/bin/
 	# Download and install bats
 	curl -sSLO https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz && tar -zxvf v${BATS_VERSION}.tar.gz && sudo bash bats-core-${BATS_VERSION}/install.sh /usr/local
 


### PR DESCRIPTION
The `storage.googleapis.com/kubernetes-release` URL is a hard coded path to a GCS bucket location. To allow redirecting and spreading the load across multiple hosting locations, the `dl.k8s.io` URL has been introduced.

xref: https://github.com/kubernetes/k8s.io/issues/2396