### PR TITLE
ci: enable tests with kubernetes v1.29

### DIFF
--- a/.pipelines/templates/e2e-kind-template.yml
+++ b/.pipelines/templates/e2e-kind-template.yml
@@ -35,8 +35,6 @@ jobs:
           KUBERNETES_VERSION: v1.27.11
         kmsv1_kind_v1_28_7:
           KUBERNETES_VERSION: v1.28.7
-        kmsv1_kind_v1_29_2:
-          KUBERNETES_VERSION: v1.29.2
     steps:
       - task: GoTool@0
         inputs:

--- a/.pipelines/templates/e2e-kind-template.yml
+++ b/.pipelines/templates/e2e-kind-template.yml
@@ -2,6 +2,10 @@ jobs:
   - job:
     timeoutInMinutes: 15
     cancelTimeoutInMinutes: 5
+    pool:
+      name: staging-pool-amd64-mariner-2
+      demands:
+      - ImageOverride -equals azcu-agent-amd64-mariner-2-cgv2-img
     workspace:
       clean: all
     variables:
@@ -25,14 +29,14 @@ jobs:
     - group: kubernetes-kms
     strategy:
       matrix:
-        kmsv1_kind_v1_24_7:
-          KUBERNETES_VERSION: v1.24.7
-        kmsv1_kind_v1_25_3:
-          KUBERNETES_VERSION: v1.25.3
-        kmsv1_kind_v1_26_0:
-          KUBERNETES_VERSION: v1.26.0
-        kmsv1_kind_v1_27_1:
-          KUBERNETES_VERSION: v1.27.1
+        kmsv1_kind_v1_26_14:
+          KUBERNETES_VERSION: v1.26.14
+        kmsv1_kind_v1_27_11:
+          KUBERNETES_VERSION: v1.27.11
+        kmsv1_kind_v1_28_7:
+          KUBERNETES_VERSION: v1.28.7
+        kmsv1_kind_v1_29_2:
+          KUBERNETES_VERSION: v1.29.2
     steps:
       - task: GoTool@0
         inputs:
@@ -81,8 +85,12 @@ jobs:
     - group: kubernetes-kms
     strategy:
       matrix:
-        kmsv2_kind_v1_27_1:
-          KUBERNETES_VERSION: v1.27.1
+        kmsv2_kind_v1_27_11:
+          KUBERNETES_VERSION: v1.27.11
+        kmsv2_kind_v1_28_7:
+          KUBERNETES_VERSION: v1.28.7
+        kmsv2_kind_v1_29_2:
+          KUBERNETES_VERSION: v1.29.2
     steps:
       - task: GoTool@0
         inputs:

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ DOCKER_BUILDKIT = 1
 export DOCKER_BUILDKIT
 
 # Testing var
-KIND_VERSION ?= 0.18.0
-KUBERNETES_VERSION ?= v1.27.1
+KIND_VERSION ?= 0.22.0
+KUBERNETES_VERSION ?= v1.29.3
 BATS_VERSION ?= 1.4.1
 
 ## --------------------------------------

--- a/tests/e2e/testkmsv2.bats
+++ b/tests/e2e/testkmsv2.bats
@@ -52,6 +52,7 @@ setup() {
 
     hashIDs=$(echo "${metrics}" | grep -oP 'sha256:\K[a-f0-9]+')
     for hash in ${hashIDs}; do
+        echo ${hash}
         [[ "${hash}" == "${expected_hash}" ]]
     done
 }


### PR DESCRIPTION
- enable tests with kubernetes v1.29
- remove 1.24 and 1.25 (EOL)
