### PR TITLE
ci: bump ossf/scorecard-action to v2.3.1

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Updating `ossf/scorecard-action` to latest (v2.3.1) to resolves [failures](https://github.com/Azure/kubernetes-kms/actions/runs/8742259890/job/23990093097).

xref: https://github.com/ossf/scorecard-action/issues/997