### PR TITLE
ci: use msi to authenticate with keyvault

### DIFF
--- a/tests/e2e/azure.json
+++ b/tests/e2e/azure.json
@@ -1,7 +1,7 @@
 {
     "cloud": "AzurePublicCloud",
     "tenantId": "$AZURE_TENANT_ID",
-    "aadClientId": "$AZURE_CLIENT_ID",
-    "aadClientSecret": "$AZURE_CLIENT_SECRET"
+    "useManagedIdentityExtension": true,
+    "userAssignedIdentityID": "$USER_ASSIGNED_IDENTITY_ID"
 }
 


### PR DESCRIPTION
- use msi to authenticate with keyvault

As we're using kind clusters for CI, we can leverage the ado-agent identity to authenticate with keyvault. With this change, we can get rid of the service principal.