### PR TITLE
ci: use msi to authenticate with keyvault (cleanup)

### DIFF
--- a/.pipelines/templates/e2e-kind-template.yml
+++ b/.pipelines/templates/e2e-kind-template.yml
@@ -16,12 +16,11 @@ jobs:
     - name: KIND_NETWORK
       value: kind
     # contains the following environment variables:
-    # - AZURE_CLIENT_ID
-    # - AZURE_CLIENT_SECRET
     # - AZURE_TENANT_ID
     # - KEYVAULT_NAME
     # - KEY_NAME
     # - KEY_VERSION
+    # - USER_ASSIGNED_IDENTITY_ID
     - group: kubernetes-kms
     strategy:
       matrix:
@@ -48,8 +47,6 @@ jobs:
           KUBERNETES_VERSION: $(KUBERNETES_VERSION)
           KIND_CLUSTER_NAME: $(KIND_CLUSTER_NAME)
           KIND_NETWORK: $(KIND_NETWORK)
-          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
       - template: cluster-health-template.yml
       - template: kind-debug-template.yml
       - script: make e2e-test
@@ -72,12 +69,11 @@ jobs:
     - name: KIND_NETWORK
       value: kind
     # contains the following environment variables:
-    # - AZURE_CLIENT_ID
-    # - AZURE_CLIENT_SECRET
     # - AZURE_TENANT_ID
     # - KEYVAULT_NAME
     # - KEY_NAME
     # - KEY_VERSION
+    # - USER_ASSIGNED_IDENTITY_ID
     - group: kubernetes-kms
     strategy:
       matrix:
@@ -98,8 +94,6 @@ jobs:
           KUBERNETES_VERSION: $(KUBERNETES_VERSION)
           KIND_CLUSTER_NAME: $(KIND_CLUSTER_NAME)
           KIND_NETWORK: $(KIND_NETWORK)
-          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
       - template: cluster-health-template.yml
       - template: kind-debug-template.yml
       - script: make e2e-kmsv2-test

--- a/.pipelines/templates/e2e-upgrade-template.yml
+++ b/.pipelines/templates/e2e-upgrade-template.yml
@@ -16,12 +16,11 @@ jobs:
       - name: KIND_NETWORK
         value: kind
       # contains the following environment variables:
-      # - AZURE_CLIENT_ID
-      # - AZURE_CLIENT_SECRET
       # - AZURE_TENANT_ID
       # - KEYVAULT_NAME
       # - KEY_NAME
       # - KEY_VERSION
+      # - USER_ASSIGNED_IDENTITY_ID
       - group: kubernetes-kms
 
     steps:

--- a/.pipelines/templates/manifest-template.yml
+++ b/.pipelines/templates/manifest-template.yml
@@ -17,6 +17,3 @@ steps:
       echo "##vso[task.setvariable variable=REGISTRY]${{ parameters.registry }}"
       echo "##vso[task.setvariable variable=IMAGE_NAME]${{ parameters.imageName }}"
     displayName: "Generate Manifests"
-    env:
-      AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)

--- a/.pipelines/templates/unit-tests-template.yml
+++ b/.pipelines/templates/unit-tests-template.yml
@@ -6,12 +6,11 @@ jobs:
       clean: all
     variables:
       # contains the following environment variables:
-      # - AZURE_CLIENT_ID
-      # - AZURE_CLIENT_SECRET
       # - AZURE_TENANT_ID
       # - KEYVAULT_NAME
       # - KEY_NAME
       # - KEY_VERSION
+      # - USER_ASSIGNED_IDENTITY_ID
     - group: kubernetes-kms
 
     steps:
@@ -26,12 +25,9 @@ jobs:
         displayName: Check binary version
       - script: |
           sudo mkdir /etc/kubernetes
-          echo -e '{\n    "tenantId": "'$AZURE_TENANT_ID'",\n    "aadClientId": "'$AZURE_CLIENT_ID'",\n    "aadClientSecret": "'$AZURE_CLIENT_SECRET'",\n}' | sudo tee --append /etc/kubernetes/azure.json  > /dev/null
+          echo -e '{\n    "tenantId": "'$AZURE_TENANT_ID'",\n    "useManagedIdentityExtension": true,\n    "userAssignedIdentityID": "'$USER_ASSIGNED_IDENTITY_ID'",\n}' | sudo tee --append /etc/kubernetes/azure.json  > /dev/null
           sudo chown root:root /etc/kubernetes/azure.json && sudo chmod 600 /etc/kubernetes/azure.json
         displayName: Setup azure.json on host
-        env:
-          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
       - script: |
           sudo ./_output/kubernetes-kms --keyvault-name $KEYVAULT_NAME --key-name $KEY_NAME --key-version $KEY_VERSION --listen-addr "unix:///opt/azurekms.sock" > /dev/null &
           echo Waiting 2 seconds for the server to start


### PR DESCRIPTION
- PR to cleanup references to `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` in the pipelines.
- Also using this to validate pipelines work as expected after removing the client id and secret variables from library.