### PR TITLE
release: bump version to v0.8.0

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,23 +9,22 @@ permissions:
 
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6b3083af2869dc3314a0257a42f4af696cc79ba3 # v2.3.1
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
         with:
           egress-policy: audit
 
-      - name: Checkout
-      # pinning to the sha ec3a7ce113134d7a93b817d10a8272cb61118579 from https://github.com/actions/checkout/releases/tag/v2.4.0
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
+          submodules: true
           fetch-depth: 0
-      # pinning to the sha b953231f81b8dfd023c58e0854a721e35037f28b from https://github.com/goreleaser/goreleaser-action/releases/tag/v2.9.1
+
       - name: Goreleaser
-        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b
+        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
-          version: latest
-          args: release --rm-dist --timeout 60m --debug
+          version: "~> v2"
+          args: release --clean --fail-fast --timeout 60m --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,13 @@
 # refer to https://goreleaser.com for more options
-build:
-  skip: true
+version: 2
+builds:
+- skip: true
 release:
   prerelease: auto
   header: |
     ## {{.Tag}} - {{ time "2006-01-02" }}
 changelog:
-  skip: false
+  disabled: false
   groups:
     - title: Bug Fixes 🐞
       regexp: ^.*fix[(\\w)]*:+.*$

--- a/.pipelines/templates/e2e-upgrade-template.yml
+++ b/.pipelines/templates/e2e-upgrade-template.yml
@@ -43,7 +43,7 @@ jobs:
       
       - template: manifest-template.yml
         parameters:
-          registry: mcr.microsoft.com/oss/azure/kms
+          registry: mcr.microsoft.com/oss/v2/azure/kms
           imageName: keyvault
           imageVersion: $(LATEST_KMS_VERSION)
 

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -66,7 +66,7 @@ This guide demonstrates steps required to enable the KMS Plugin for Key Vault in
     hostNetwork: true
     containers:
       - name: azure-kms-provider
-        image: mcr.microsoft.com/oss/azure/kms/keyvault:v0.7.0
+        image: mcr.microsoft.com/oss/v2/azure/kms/keyvault:v0.8.0
         imagePullPolicy: IfNotPresent
         args:
           - --listen-addr=unix:///opt/azurekms.socket             # [OPTIONAL] gRPC listen address. Default is unix:///opt/azurekms.socket

--- a/docs/rotation.md
+++ b/docs/rotation.md
@@ -29,7 +29,7 @@ spec:
   hostNetwork: true
   containers:
     - name: azure-kms-provider
-      image: mcr.microsoft.com/oss/azure/kms/keyvault:v0.7.0
+      image: mcr.microsoft.com/oss/v2/azure/kms/keyvault:v0.8.0
       imagePullPolicy: IfNotPresent
       args:
       - --listen-addr=unix:///opt/azurekms2.socket            # unix:///opt/azurekms.socket is used by the primary kms plugin pod. So use a different listen address here for the new kms plugin pod.


### PR DESCRIPTION
- update goreleaser config for v2
- bump version to v0.8.0

Image will be `mcr.microsoft.com/oss/v2/azure/kms` (v2) because we're building it with dalec now.