### PR TITLE
chore: Bump Go toolchain pins to 1.26.3 for CVE remediation

### DIFF
--- a/.pipelines/templates/e2e-kind-template.yml
+++ b/.pipelines/templates/e2e-kind-template.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.26.2
+          version: 1.26.3
       - template: prepare-deps.yaml
       - script: make e2e-install-prerequisites
         displayName: "Install e2e test prerequisites"
@@ -85,7 +85,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.26.2
+          version: 1.26.3
       - template: prepare-deps.yaml
       - script: make e2e-install-prerequisites
         displayName: "Install e2e test prerequisites"

--- a/.pipelines/templates/e2e-upgrade-template.yml
+++ b/.pipelines/templates/e2e-upgrade-template.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.26.2
+          version: 1.26.3
       - template: prepare-deps.yaml
 
       - script: make e2e-install-prerequisites

--- a/.pipelines/templates/unit-tests-template.yml
+++ b/.pipelines/templates/unit-tests-template.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.26.2
+          version: 1.26.3
       - template: prepare-deps.yaml
       - script: make lint
         displayName: Run lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm@sha256:61e607875d60ae21a7a4a49110fe7098355473fbc74ab13091e3c1160cc92f18 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm@sha256:6ea3c258390542b7d13515be11a31ce797dd5150c9d46ae21c47f0f1ce2786cb AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kubernetes-kms
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kubernetes-kms/tools
 
-go 1.26.2
+go 1.26.3
 
 require github.com/golangci/golangci-lint/v2 v2.7.2
 


### PR DESCRIPTION
<!-- Thank you for helping KMS Plugin for Key Vault with a pull request! -->

**Reason for Change**:
<!-- What does this PR improve or fix in KMS Plugin for Key Vault? Why is it needed? -->
Bump Go toolchain pins to 1.26.3 for CVE remediation

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
[
	"CVE-2026-39823",
	"CVE-2026-33811",
	"CVE-2026-39826",
	"CVE-2026-39836",
	"CVE-2026-39820",
	"CVE-2026-33814",
	"CVE-2026-42499",
	"CVE-2026-39825"
]

**Notes for Reviewers**:
