### PR TITLE
security: bump Go toolchain to 1.26.5 to resolve stdlib CVEs

### DIFF
--- a/.pipelines/templates/e2e-kind-template.yml
+++ b/.pipelines/templates/e2e-kind-template.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.26.4
+          version: 1.26.5
       - template: prepare-deps.yaml
       - script: make e2e-install-prerequisites
         displayName: "Install e2e test prerequisites"
@@ -105,7 +105,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.26.4
+          version: 1.26.5
       - template: prepare-deps.yaml
       - script: make e2e-install-prerequisites
         displayName: "Install e2e test prerequisites"

--- a/.pipelines/templates/e2e-upgrade-template.yml
+++ b/.pipelines/templates/e2e-upgrade-template.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.26.4
+          version: 1.26.5
       - template: prepare-deps.yaml
 
       - script: make e2e-install-prerequisites

--- a/.pipelines/templates/unit-tests-template.yml
+++ b/.pipelines/templates/unit-tests-template.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: 1.26.4
+          version: 1.26.5
       - template: prepare-deps.yaml
       - script: make lint
         displayName: Run lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-bookworm@sha256:7e9339662bf964ba4bfa6ca572c391239d18ca22b37c11d15cf92adbc9082cd8 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.5-bookworm@sha256:be89027d698a8bcec2f8b6e9af8923f485fad6fde033b91c7d4ad8a70410707b AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kubernetes-kms
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kubernetes-kms/tools
 
-go 1.26.4
+go 1.26.5
 
 require github.com/golangci/golangci-lint/v2 v2.7.2
 


### PR DESCRIPTION
## Summary
Resolves the two fixed-status vulnerabilities flagged by the trivy `gobinary` scan on the `kubernetes-kms` binary:

- **CVE-2026-39822** (HIGH) — `os`: Go `os.Root` symlink-following vulnerability allows directory traversal
- **CVE-2026-42505** (MEDIUM) — `crypto/tls`: information disclosure in Encrypted Client Hello

Both are Go standard-library issues fixed in Go `1.25.12` / `1.26.5` / `1.27.0-rc.2`. The binary was built with `1.26.4`, so bumping the toolchain to `1.26.5` clears both.

## Changes
- `go.mod` / `tools/go.mod`: `go` directive `1.26.4` → `1.26.5`
- `Dockerfile`: golang builder image `1.26.4-bookworm` → `1.26.5-bookworm` (digest updated)
- `.pipelines/templates/*`: pipeline Go version pins `1.26.4` → `1.26.5`

## Note on the remaining finding
The scan also reports `GO-2026-5932` (UNKNOWN severity) for `golang.org/x/crypto/openpgp` — a deprecation/unmaintained advisory with **no fixed version**. It cannot be resolved by a version bump and is not a blocking (fixed-status) finding, so it is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)